### PR TITLE
Added error message field to Order processing API

### DIFF
--- a/src/main/java/com/angelbroking/smartapi/SmartConnect.java
+++ b/src/main/java/com/angelbroking/smartapi/SmartConnect.java
@@ -4,6 +4,7 @@ import com.angelbroking.smartapi.http.SessionExpiryHook;
 import com.angelbroking.smartapi.http.SmartAPIRequestHandler;
 import com.angelbroking.smartapi.http.exceptions.SmartAPIException;
 import com.angelbroking.smartapi.models.*;
+import com.angelbroking.smartapi.utils.Constants;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.json.JSONArray;
@@ -15,7 +16,6 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.net.Proxy;
 import java.util.List;
-import javax.net.ssl.HttpsURLConnection;
 
 import static com.angelbroking.smartapi.utils.Constants.IO_EXCEPTION_ERROR_MSG;
 import static com.angelbroking.smartapi.utils.Constants.IO_EXCEPTION_OCCURRED;
@@ -308,8 +308,16 @@ public class SmartConnect {
 
 			JSONObject jsonObject = smartAPIRequestHandler.postRequest(this.apiKey, url, params, accessToken);
 			Order order = new Order();
+
+			if(jsonObject.getJSONObject("data") == null) {
+				log.error("Order placement failed: {}", jsonObject.getString("message"));
+				order.apiErrorMessage = jsonObject.getString("message") + " - " + jsonObject.getString("errorcode");
+				order.status= Constants.ORDER_API_CALL_ERROR;
+				return order;
+			}
 			order.orderId = jsonObject.getJSONObject("data").getString("orderid");
 			order.uniqueOrderId = jsonObject.getJSONObject("data").getString("uniqueorderid");
+			order.status = Constants.ORDER_API_CALL_SUCCESS;
 			log.info("order : {}",order);
 			return order;
 		} catch (Exception | SmartAPIException e) {
@@ -356,7 +364,14 @@ public class SmartConnect {
 
 			JSONObject jsonObject = smartAPIRequestHandler.postRequest(this.apiKey, url, params, accessToken);
 			Order order = new Order();
+			if(jsonObject.getJSONObject("data") == null) {
+				log.error("Order modification failed: {}", jsonObject.getString("message"));
+				order.apiErrorMessage = jsonObject.getString("message") + " - " + jsonObject.getString("errorcode");
+				order.status= Constants.ORDER_API_CALL_ERROR;
+				return order;
+			}
 			order.orderId = jsonObject.getJSONObject("data").getString("orderid");
+			order.status = Constants.ORDER_API_CALL_SUCCESS;
 			return order;
 		} catch (Exception | SmartAPIException e) {
 			log.error(e.getMessage());
@@ -382,7 +397,16 @@ public class SmartConnect {
 
 			JSONObject jsonObject = smartAPIRequestHandler.postRequest(this.apiKey, url, params, accessToken);
 			Order order = new Order();
+			if(jsonObject.getJSONObject("data") == null) {
+				log.error("Order cancellation failed: {}", jsonObject.getString("message"));
+				order.apiErrorMessage = jsonObject.getString("message") + " - " + jsonObject.getString("errorcode");
+				order.status= Constants.ORDER_API_CALL_ERROR;
+				return order;
+			}
+
 			order.orderId = jsonObject.getJSONObject("data").getString("orderid");
+			order.status= Constants.ORDER_API_CALL_SUCCESS;
+
 			return order;
 		} catch (Exception | SmartAPIException e) {
 			log.error(e.getMessage());

--- a/src/main/java/com/angelbroking/smartapi/models/Order.java
+++ b/src/main/java/com/angelbroking/smartapi/models/Order.java
@@ -112,6 +112,9 @@ public class Order {
 	@SerializedName("uniqueorderid")
 	public String uniqueOrderId;
 
+	@SerializedName("errorMessage")
+	public String apiErrorMessage;
+
 	@Override
 	public String toString() {
 		return "Order [disclosedQuantity=" + disclosedQuantity + ", duration=" + duration + ", tradingSymbol="
@@ -125,7 +128,7 @@ public class Order {
 				+ instrumentType + ", strikePrice=" + strikePrice + ", optionType=" + optionType + ", expiryDate="
 				+ expiryDate + ", lotSize=" + lotSize + ", cancelSize=" + cancelSize + ", filledShares=" + filledShares
 				+ ", orderStatus=" + orderStatus + ", unfilledShares=" + unfilledShares + ", fillId=" + fillId
-				+ ", fillTime=" + fillTime + ", uniqueorderid=" + uniqueOrderId + "]";
+				+ ", fillTime=" + fillTime + ", uniqueorderid=" + uniqueOrderId + ", errorMessage=" + apiErrorMessage + "]";
 	}
 
 }

--- a/src/main/java/com/angelbroking/smartapi/utils/Constants.java
+++ b/src/main/java/com/angelbroking/smartapi/utils/Constants.java
@@ -39,7 +39,10 @@ public class Constants {
     public static String EXCHANGE_CDS = "CDS";
     public static String EXCHANGE_NCDEX = "NCDEX";
     public static String EXCHANGE_MCX = "MCX";
-    
+
+    public static  String ORDER_API_CALL_SUCCESS = "APICallSuccess";
+    public static  String ORDER_API_CALL_ERROR = "APICallError";
+
     /**
      * LTP QUOTE SNAPQUOTE Constants
      */

--- a/src/test/java/com/angelbroking/smartapi/SmartConnectTest.java
+++ b/src/test/java/com/angelbroking/smartapi/SmartConnectTest.java
@@ -149,6 +149,7 @@ public class SmartConnectTest {
 
         Order placeOrder = smartConnect.placeOrder(orderParams,"STOPLOSS");
         assertNotNull(placeOrder);
+        assertEquals(Constants.ORDER_API_CALL_SUCCESS, placeOrder.status);
     }
 
     @Test(expected = SmartAPIException.class)
@@ -224,6 +225,7 @@ public class SmartConnectTest {
 
         Order modifyOrder = smartConnect.modifyOrder(orderResponse.orderId,orderParams, orderParams.variety);
         assertNotNull(modifyOrder);
+        assertEquals(Constants.ORDER_API_CALL_SUCCESS, modifyOrder.status);
     }
 
     @Test
@@ -236,6 +238,7 @@ public class SmartConnectTest {
 
         Order cancelOrder = smartConnect.cancelOrder(orderResponse.orderId,Constants.VARIETY_NORMAL);
         assertNotNull(cancelOrder);
+        assertEquals(Constants.ORDER_API_CALL_SUCCESS, cancelOrder.status);
     }
 
     @Test


### PR DESCRIPTION
- The APIerrormessage will give the errors like AB2001 on failure. Currently there was no way to figure out the error than debugging the library.
- This help SDK users let immediately know id api call was success or failure with the error message as well.
- in case of error there was no 'data' field in jsonresponse hence it was getting shut with null pointer error